### PR TITLE
Add Google Search Console verification file.

### DIFF
--- a/google7061d72c536b2e8d.html
+++ b/google7061d72c536b2e8d.html
@@ -1,0 +1,1 @@
+google-site-verification: google7061d72c536b2e8d.html


### PR DESCRIPTION
I wanted to investigate the SEO situation for the new https://druid.apache.org/ website using the Google Search Console: https://search.google.com/search-console/about. To do this, Google wants me to prove that I am affiliated with druid.apache.org by placing this HTML file at the web root.