### PR TITLE
Community page updates.

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -6,19 +6,29 @@ layout: simple_page
 
 ## Community
 
-Most discussion about Druid happens over email and GitHub.
+Most discussion about Druid happens over email and GitHub, but those aren't the only way to interact with the Druid
+community. We also do chat, meetups, and more. Check out the following resources if you're looking for help, to discuss
+Druid development, or just stay up to date:
 
-* **User mailing list** [druid-user@googlegroups.com](https://groups.google.com/forum/#!forum/druid-user) for general discussion
-* **Development mailing list** [dev@druid.apache.org](https://lists.apache.org/list.html?dev@druid.apache.org) for discussion about project development
-* **GitHub** [apache/druid](https://github.com/apache/druid) issues and pull requests (watch to subscribe)
-* **Meetups** [Druid meetups](https://www.meetup.com/topics/apache-druid/) for different meetup groups around the world.
-* **IRC** `#druid-dev` on irc.freenode.net
+* **User mailing list:** [druid-user@googlegroups.com](https://groups.google.com/forum/#!forum/druid-user) for general
+discussion, questions, and announcements. This is the perfect place to ask for help if you need it!
+* **Development mailing list:** [dev@druid.apache.org](https://lists.apache.org/list.html?dev@druid.apache.org) for
+discussion about project development.
+* **GitHub:** Star us at [apache/druid](https://github.com/apache/druid) and use this to follow Druid development, raise
+issues, or contribute pull requests. If you're interested in development, please see the [Contributing](#contributing)
+section below for details on our development process.
+* **Meetups:** Check out [Apache Druid on meetup.com](https://www.meetup.com/topics/apache-druid/) for links to regular
+meetups in cities all over the world.
+* **Slack:** Some committers and users are present in the channel `#druid` on the Apache Slack team at [the-asf.slack.com](https://the-asf.slack.com). Please use our invitation link to join: https://druid.apache.org/community/join-slack.
+* **Twitter:** Follow us on Twitter at [@druidio](https://twitter.com/druidio).
+* **StackOverflow:** While the user mailing list is the primary resource for asking questions, if you prefer
+StackOverflow, make sure to tag your question with `druid` or `apache-druid`.
 
 ## Getting help
 
 The best place to get a wide variety of help about Druid is on the Druid user
-group [druid-user@googlegroups.com](https://groups.google.com/forum/#!forum/druid-user). You can also report issues and bugs on
-the [Github development page](https://github.com/apache/druid).
+group [druid-user@googlegroups.com](https://groups.google.com/forum/#!forum/druid-user). You can also report issues and problems, or suggest
+new features, on [GitHub](https://github.com/apache/druid).
 
 Third party companies also provide commercial support and services for Druid, including:
 

--- a/community/join-slack.md
+++ b/community/join-slack.md
@@ -1,0 +1,4 @@
+---
+layout: redirect_page
+redirect_target: https://join.slack.com/t/the-asf/shared_invite/enQtNDQ3OTEwNzE1MDg5LWY2NjkwMTEzMGI2ZTI1NzUzMDk0MzJmMWM1NWVmODg0MzBjNjAxYzUwMjIwNDI3MjlhZWRjNmNhOTM5NmIxNDk
+---


### PR DESCRIPTION
- Add link to ASF Slack
- Add link to Twitter account
- Add info about StackOverflow tags people can use to ask questions
- Remove link to IRC, it doesn't seem very popular anymore