### PR TITLE
Fix Slack link

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -20,7 +20,7 @@ section below for details on our development process.
 * **Meetups:** Check out [Apache Druid on meetup.com](https://www.meetup.com/topics/apache-druid/) for links to regular
 meetups in cities all over the world.
 * **Slack:** Some committers and users are present in the channel `#druid` on the Apache Slack team. Please use our
-[invitation link to join](https://druid.apache.org/community/join-slack), and once you join, add the `#druid` channel.
+[invitation link to join](https://s.apache.org/slack-invite), and once you join, add the `#druid` channel.
 * **Twitter:** Follow us on Twitter at [@druidio](https://twitter.com/druidio).
 * **StackOverflow:** While the user mailing list is the primary resource for asking questions, if you prefer
 StackOverflow, make sure to tag your question with `druid` or `apache-druid`.

--- a/community/join-slack.md
+++ b/community/join-slack.md
@@ -1,4 +1,4 @@
 ---
 layout: redirect_page
-redirect_target: https://join.slack.com/t/the-asf/shared_invite/enQtNDQ3OTEwNzE1MDg5LWY2NjkwMTEzMGI2ZTI1NzUzMDk0MzJmMWM1NWVmODg0MzBjNjAxYzUwMjIwNDI3MjlhZWRjNmNhOTM5NmIxNDk
+redirect_target: https://s.apache.org/slack-invite
 ---


### PR DESCRIPTION
From ASF Infra channel:

![image](https://user-images.githubusercontent.com/177816/65727537-dd930380-e06c-11e9-9c3c-fe978711312a.png)

Using `https://s.apache.org/slack-invite` directly